### PR TITLE
Reworked cuda-based images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,21 @@ all: alpine-cmake alpine-cmake-doxygen alpine-max-cmake cuda-cmake
 
 namespace=tingoose
 
-alpine-cmake:
+alpine-cmake_SRC = $(wildcard alpine-cmake/*)
+alpine-cmake: $(alpine-cmake_SRC)
 	docker build -t $(namespace)/alpine-cmake ./alpine-cmake
 
-alpine-max-cmake: alpine-cmake
+alpine-max-cmake_SRC = $(wildcard alpine-max-cmake/*)
+alpine-max-cmake: alpine-cmake $(alpine-max-cmake_SRC)
 	docker build -t $(namespace)/alpine-max-cmake ./alpine-max-cmake
 
-alpine-cmake-doxygen: alpine-cmake
+
+alpine-cmake-doxygen_SRC = $(wildcard alpine-cmake-doxygen/*)
+alpine-cmake-doxygen: alpine-cmake $(alpine-cmake-doxygen_SRC)
 	docker build -t $(namespace)/alpine-cmake-doxygen ./alpine-cmake-doxygen
 
-cuda-cmake:
+cuda-cmake_SRC = $(wildcard cuda-cmake_SRC/*)
+cuda-cmake: $(cuda-cmake_SRC)
 	docker build -t $(namespace)/cuda-cmake ./cuda-cmake
 
 push: alpine-cmake alpine-max-cmake alpine-cmake-doxygen cuda-cmake

--- a/cuda-cmake/Dockerfile
+++ b/cuda-cmake/Dockerfile
@@ -1,8 +1,5 @@
 FROM nvidia/cuda:11.2.2-devel-ubuntu18.04
 
-ARG OPENCV_VERSION=3.4.0
-ARG OPENCV_INSTALL_PATH=/opencv/usr
-
 RUN apt-get update && \
     apt-get install -y \
 		python-pip \
@@ -40,8 +37,10 @@ RUN apt-get update && \
 		## Cleanup
 		&& rm -rf /var/lib/apt/lists/*
 
+ARG CMAKE_VERSION=3.20.5
+
 ENV DEBIAN_FRONTEND="noninteractive"
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.sh \
+RUN wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh \
       -q -O /tmp/cmake-install.sh \
       && chmod u+x /tmp/cmake-install.sh \
       && mkdir /usr/bin/cmake \
@@ -49,50 +48,3 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5
       && rm /tmp/cmake-install.sh
 
 ENV PATH="/usr/bin/cmake/bin:${PATH}"
-
-RUN mkdir -p $OPENCV_INSTALL_PATH; exit 0
-
-WORKDIR /
-
-## Single command to reduce image size
-## Build opencv
-RUN wget https://github.com/opencv/opencv/archive/$OPENCV_VERSION.zip \
-    && unzip $OPENCV_VERSION.zip \
-    && mkdir /opencv-$OPENCV_VERSION/cmake_binary \
-    && cd /opencv-$OPENCV_VERSION/cmake_binary \
-    && cmake -DBUILD_TIFF=ON \
-       -DBUILD_opencv_java=OFF \
-       -DBUILD_SHARED_LIBS=OFF \
-       -DWITH_CUDA=ON \
-       # -DENABLE_FAST_MATH=1 \
-       # -DCUDA_FAST_MATH=1 \
-       # -DWITH_CUBLAS=1 \
-       -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-10.2 \
-       -DCUDA_ARCH_BIN='3.0 3.5 5.0 6.0 6.2' \
-       -DCUDA_ARCH_PTX="" \
-       ## AVX in dispatch because not all machines have it
-       -DCPU_DISPATCH=AVX,AVX2 \
-       -DENABLE_PRECOMPILED_HEADERS=OFF \
-       -DWITH_OPENGL=OFF \
-       -DWITH_OPENCL=OFF \
-       -DWITH_QT=OFF \
-       -DWITH_IPP=ON \
-       -DWITH_TBB=ON \
-       -DFORCE_VTK=ON \
-       -DWITH_EIGEN=ON \
-       -DWITH_V4L=ON \
-       -DWITH_XINE=ON \
-       -DWITH_GDAL=ON \
-       -DWITH_1394=OFF \
-       -DWITH_FFMPEG=OFF \
-       -DBUILD_PROTOBUF=OFF \
-       -DBUILD_TESTS=OFF \
-       -DBUILD_PERF_TESTS=OFF \
-       -DCMAKE_BUILD_TYPE=RELEASE \
-       -DCMAKE_INSTALL_PREFIX=$OPENCV_INSTALL_PATH \
-    .. \
-    && export NUMPROC=$(nproc --all) \
-    && make -j$NUMPROC install \
-    ## Remove following lines if you need to move openCv \
-    && rm /$OPENCV_VERSION.zip \
-    && rm -r /opencv-$OPENCV_VERSION

--- a/cuda-opencv/Dockerfile
+++ b/cuda-opencv/Dockerfile
@@ -1,0 +1,51 @@
+FROM tingoose/cuda-cmake
+
+ARG OPENCV_VERSION=3.4.0
+ARG OPENCV_INSTALL_PATH=/opencv/usr
+
+RUN mkdir -p $OPENCV_INSTALL_PATH; exit 0
+
+WORKDIR /
+
+## Single command to reduce image size
+## Build opencv
+RUN wget https://github.com/opencv/opencv/archive/$OPENCV_VERSION.zip \
+    && unzip $OPENCV_VERSION.zip \
+    && mkdir /opencv-$OPENCV_VERSION/cmake_binary \
+    && cd /opencv-$OPENCV_VERSION/cmake_binary \
+    && cmake -DBUILD_TIFF=ON \
+       -DBUILD_opencv_java=OFF \
+       -DBUILD_SHARED_LIBS=OFF \
+       -DWITH_CUDA=ON \
+       # -DENABLE_FAST_MATH=1 \
+       # -DCUDA_FAST_MATH=1 \
+       # -DWITH_CUBLAS=1 \
+       -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-10.2 \
+       -DCUDA_ARCH_BIN='3.0 3.5 5.0 6.0 6.2' \
+       -DCUDA_ARCH_PTX="" \
+       ## AVX in dispatch because not all machines have it
+       -DCPU_DISPATCH=AVX,AVX2 \
+       -DENABLE_PRECOMPILED_HEADERS=OFF \
+       -DWITH_OPENGL=OFF \
+       -DWITH_OPENCL=OFF \
+       -DWITH_QT=OFF \
+       -DWITH_IPP=ON \
+       -DWITH_TBB=ON \
+       -DFORCE_VTK=ON \
+       -DWITH_EIGEN=ON \
+       -DWITH_V4L=ON \
+       -DWITH_XINE=ON \
+       -DWITH_GDAL=ON \
+       -DWITH_1394=OFF \
+       -DWITH_FFMPEG=OFF \
+       -DBUILD_PROTOBUF=OFF \
+       -DBUILD_TESTS=OFF \
+       -DBUILD_PERF_TESTS=OFF \
+       -DCMAKE_BUILD_TYPE=RELEASE \
+       -DCMAKE_INSTALL_PREFIX=$OPENCV_INSTALL_PATH \
+    .. \
+    && export NUMPROC=$(nproc --all) \
+    && make -j$NUMPROC install \
+    ## Remove following lines if you need to move openCv \
+    && rm /$OPENCV_VERSION.zip \
+    && rm -r /opencv-$OPENCV_VERSION

--- a/cuda-physics/Dockerfile
+++ b/cuda-physics/Dockerfile
@@ -1,0 +1,12 @@
+FROM tingoose/cuda-cmake
+
+RUN apt-get update && apt-get install -y software-properties-common
+
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test && \
+	apt-get update && \
+    apt-get install -y \
+    	gcc-9 \
+    	g++-9 \
+		libglew-dev \
+		freeglut3-dev && \
+	update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9


### PR DESCRIPTION
Moved OpenCV part from cuda-cmake to cuda-opencv.

Introduced a new image cuda-physics, which is based on cuda-cmake and have gcc-9, freeglut and glew for our local physics project